### PR TITLE
fix(websocket): 参加をトリガーにルームマスターにリクエストを送信しないように

### DIFF
--- a/src/websocket.gateway.ts
+++ b/src/websocket.gateway.ts
@@ -142,10 +142,6 @@ export class WebsocketGateway {
     this.rooms.join(room_id, user); // データ側
     client.join(room_id); // WebSocket側
 
-    // ルームマスターにplayingDataをリクエスト
-
-    this.requestPlayingData(room.roomMaster, user.id);
-
     return true;
   }
 


### PR DESCRIPTION
# 内容
🖊️ フロントの変更をうけ、新規ユーザ参加をトリガーにルームマスターへ `request_playing_data` を送信することはなくなりました。